### PR TITLE
Update middleware registry for Faraday 0.9

### DIFF
--- a/lib/faraday_middleware/multi_json.rb
+++ b/lib/faraday_middleware/multi_json.rb
@@ -25,5 +25,5 @@ module FaradayMiddleware
   end
 end
 
-Faraday.register_middleware :response, :multi_json => FaradayMiddleware::MultiJson::ParseJson
-Faraday.register_middleware :request, :multi_json => FaradayMiddleware::MultiJson::EncodeJson
+Faraday::Response.register_middleware :multi_json => FaradayMiddleware::MultiJson::ParseJson
+Faraday::Request.register_middleware :multi_json => FaradayMiddleware::MultiJson::EncodeJson


### PR DESCRIPTION
The unified method `Faraday.register_middleware` for registering all
kinds of middleware was gone in 0.9.

https://github.com/lostisland/faraday/commit/14b458a9c971897f44d5ee3ba5354de52c998e72
